### PR TITLE
Sandbox: step8

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,11 +6,13 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 01:47:03 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/10/16 00:16:31 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/10/16 13:02:20 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
+
+t_bool	g_syntax_error = FALSE;
 
 int	main(void)
 {
@@ -29,8 +31,11 @@ int	main(void)
 			add_history(line);
 			tok = tokenize(line);
 			node = parse(tok);
-			node = expand(node);
-			interpret(node);
+			if (!g_syntax_error)
+			{
+				node = expand(node);
+				interpret(node);
+			}
 		}
 		free(line);
 	}

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -12,6 +12,17 @@
 
 #include "minishell.h"
 
+extern t_bool	g_syntax_error;
+
+void	parse_error(const char *location, t_token **rest, t_token *tok)
+{
+	g_syntax_error = TRUE;
+	dprintf(STDERR_FILENO, "minishell: syntax error near %s\n", location);
+	while (tok->kind != TK_EOF)
+		tok = tok->next;
+	*rest = tok;
+}
+
 t_bool	at_eof(t_token *tok)
 {
 	return (tok->kind == TK_EOF);
@@ -57,7 +68,11 @@ t_node	*parse(t_token *tok)
 	{
 		if (tok->kind == TK_WORD)
 			append_tok(&node->args, tokdup(tok));
-		// TODO : ↑このエラー処理. 
+		else
+		{
+			parse_error(node->args->word, &tok, tok);
+			break ;
+		}
 		tok = tok->next;
 	}
 	return (node);

--- a/src/tokenize/tokenize.c
+++ b/src/tokenize/tokenize.c
@@ -6,14 +6,14 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 14:00:20 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/10/15 23:50:10 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/10/16 13:04:11 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 // TODO: グローバル変数は後でまとめて大きな構造体に入れる. 
-t_bool	syntax_error = FALSE;
+extern t_bool	g_syntax_error;
 
 void	assert_error(const char *msg)
 {
@@ -22,7 +22,7 @@ void	assert_error(const char *msg)
 
 void	tokenize_error(const char *location, char **rest, char *line)
 {
-	syntax_error = TRUE;
+	g_syntax_error = TRUE;
 	dprintf(STDERR_FILENO, "minishell: syntax error near %s\n", location);
 	while (*line)
 		line++;


### PR DESCRIPTION
## やったこと
- グローバル変数`syntax_error`を`g_syntax_error`に変更. 
- グローバル変数`g_syntax_error`の定義場所を`main.c`内に変更.
- `parse()`内のエラー処理として, `tokenize_error()`を参考に`parse_error()`を作成. 

## やってないこと
- `parse_error()`が正しく機能するのかの確認. (現時点ではtokenizeで弾かれるエラーケースしかないので, redirection以降で確認する. )