### PR TITLE
25 fix env dup =

### DIFF
--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/21 14:51:22 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/11/21 14:58:46 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/11/29 12:30:05 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,6 @@ int	builtin_env(char **argv)
 			ft_printf("%s=%s\n", item->key, item->value);
 		item = item->next;
 	}
-	// これ/usr/bin/envの実行権限無くした時も出ちゃわない？？
 	ft_printf("_=/usr/bin/env\n");
 	return (0);
 }

--- a/src/env/env.c
+++ b/src/env/env.c
@@ -6,7 +6,7 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/14 17:31:05 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/11/21 15:19:38 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/11/29 12:36:52 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ t_map	*init_env(void)
 	}
 	if (map_get(map, "OLDPWD") == NULL)
 		map_set(map, "OLDPWD", NULL);
+	map_unset(map, "_");
 	return (map);
 }
 


### PR DESCRIPTION
## やったこと
- 引数がないときの`builtin_env()`をbashの挙動と合わせた. 
- `main()`で呼び出される`init_env()`内でkeyが`_`である項目を削除した. 
- `builtin_env()`の最後で`ft_printf()`を使用して`_=/usr/bin/env`が出力される. 

## やってないこと
- parseかsearch_pathが死んでいるためビルトインコマンド以外使用できない ; ;
- norm

## 参照
close #25 