### PR TITLE
43 exit

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -12,6 +12,7 @@
 
 NAME = libft.a
 SRCS = ft_atoi.c \
+		ft_strtol.c \
 		ft_bzero.c \
 		ft_calloc.c \
 		ft_isalnum.c \

--- a/libft/ft_strtol.c
+++ b/libft/ft_strtol.c
@@ -1,0 +1,69 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strtol.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkitahar <tkitahar@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/08 16:24:53 by tkitahar          #+#    #+#             */
+/*   Updated: 2024/12/08 16:25:11 by tkitahar         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <errno.h>
+#include <limits.h>
+
+static int    is_overflow(unsigned long val, unsigned long next, int is_neg)
+{
+    if (is_neg)
+    {
+        if (val > ((unsigned long)LONG_MAX + 1) / 10)
+            return (1);
+        if (val == ((unsigned long)LONG_MAX + 1) / 10
+            && next > ((unsigned long)LONG_MAX + 1) % 10)
+            return (1);
+    }
+    else
+    {
+        if (val > (unsigned long)LONG_MAX / 10)
+            return (1);
+        if (val == (unsigned long)LONG_MAX / 10
+            && next > (unsigned long)LONG_MAX % 10)
+            return (1);
+    }
+    return (0);
+}
+
+long    ft_strtol(const char *str)
+{
+    unsigned long    val;
+    int             is_neg;
+    long            ret;
+
+    while (*str == ' ' || (*str >= 9 && *str <= 13))
+        str++;
+    is_neg = 0;
+    if (*str == '-' || *str == '+')
+    {
+        if (*str == '-')
+            is_neg = 1;
+        str++;
+    }
+    val = 0;
+    while (*str >= '0' && *str <= '9')
+    {
+        if (is_overflow(val, *str - '0', is_neg))
+        {
+            errno = ERANGE;
+            if (is_neg)
+                return (LONG_MIN);
+            return (LONG_MAX);
+        }
+        val = val * 10 + (*str - '0');
+        str++;
+    }
+    ret = (long)val;
+    if (is_neg)
+        ret = -ret;
+    return (ret);
+}

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/15 23:54:02 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/11/27 16:13:58 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/11/27 16:13:52 by tkitahar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,8 @@ typedef struct s_list
 }	t_list;
 
 int		ft_atoi(const char *nptr);
+
+long	ft_strtol(const char *str);
 
 void	ft_bzero(void *b, size_t len);
 

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -20,19 +20,15 @@ static void	print_and_exit(int status)
 
 static bool	is_numeric(char *s)
 {
-	long long	num;
 
-	if (!isdigit(*s))
+	if (*s == '-' || *s == '+')
+		s++;
+	if (!*s)
 		return (false);
-	num = 0;
 	while (*s)
 	{
 		if (!ft_isdigit(*s))
 			return (false);
-		if (num > LLONG_MAX / 10 || (num == LLONG_MAX / 10 && *s - '0' > LLONG_MAX % 10))
-			return (false);
-		num *= 10;
-		num += *s - '0';
 		s++;
 	}
 	return (true);
@@ -43,9 +39,7 @@ int	builtin_exit(char **argv)
 	long	res;
 	char	*arg;
 
-	if (argv == NULL)
-		print_and_exit(g_last_status);
-	if (argv[1] == NULL)
+	if (argv == NULL || argv[1] == NULL)
 		print_and_exit(g_last_status);
 	if (argv[2])
 	{
@@ -55,9 +49,13 @@ int	builtin_exit(char **argv)
 	arg = argv[1];
 	if (is_numeric(arg))
 	{
-		// TODO is_minus
-		// exit (255);
-		res = ft_atoi(argv[1]);
+		errno = 0;
+		res = ft_strtol(arg);
+		if (errno == ERANGE)
+		{
+			xperror2("exit", "numeric argument required");
+			return (2);
+		}
 		print_and_exit(res);
 	}
 	xperror2("exit", "numeric argument required");

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -20,7 +20,6 @@ static void	print_and_exit(int status)
 
 static bool	is_numeric(char *s)
 {
-
 	if (*s == '-' || *s == '+')
 		s++;
 	if (!*s)


### PR DESCRIPTION
## やったこと
- ft_strtol()を用いた、以下のテストケースの対応
```
[exit -42]                                                            :  diff OK  status NG, expected 214 but got 2
[exit +42]                                                            :  diff OK  status NG, expected 42 but got 2                                      :  diff OK  status NG, expected 1 but got 2
[exit -9223372036854775807]                                           :  diff OK  status NG, expected 1 but got 2
[exit -9223372036854775808]                                           :  diff OK  status NG, expected 0 but got 2
```

## やってないこと
- 以下のテストケースの対応
```
[exit " 42 "]
[exit + ]
[exit 6 8 ]
[exit 1 a]
[exit a a]
```

## 参照
#43 