### PR TITLE
86 fix exort a b c d

### DIFF
--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 16:15:23 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/11/19 19:15:20 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/10 10:54:18 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static void	print_allenv(void)
 		if (item->value)
 			ft_printf("declare -x %s=\"%s\"\n", item->key, item->value);
 		else
-			ft_printf("declare -x %s\n", item->value);
+			ft_printf("declare -x %s\n", item->key);
 		item = item->next;
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -403,6 +403,8 @@ assert 'export [invalid] nosuch hoge=nosuch\n export | grep nosuch | sort'
 assert 'export nosuch [invalid] hoge=nosuch\n export | grep nosuch | sort'
 assert 'export nosuch hoge=nosuch [invalid]\n export | grep nosuch | sort'
 assert 'export nosuch="nosuch2=hoge"\nexport $nosuch\n export | grep nosuch | sort'
+assert 'export a b c d'
+assert 'export e'
 
 ## unset
 (
@@ -475,6 +477,7 @@ assert 'cd /tmp/// \n pwd \n echo $PWD $OLDPWD'
 assert 'unset PWD\npwd\ncd /etc\npwd'
 
 ## export attribute
+print_desc 'export hoge fuga=fuga'
 assert 'unset PWD \n cd \n echo $PWD \ncd /tmp\necho $PWD'
 assert 'unset PWD\ncd\necho $OLDPWD\ncd /tmp\necho $OLDPWD'
 assert 'unset PWD\ncd\nexport|grep PWD\ncd /tmp\nexport|grep PWD'

--- a/test.sh
+++ b/test.sh
@@ -403,8 +403,8 @@ assert 'export [invalid] nosuch hoge=nosuch\n export | grep nosuch | sort'
 assert 'export nosuch [invalid] hoge=nosuch\n export | grep nosuch | sort'
 assert 'export nosuch hoge=nosuch [invalid]\n export | grep nosuch | sort'
 assert 'export nosuch="nosuch2=hoge"\nexport $nosuch\n export | grep nosuch | sort'
-assert 'export a b c d'
-assert 'export e'
+assert 'export a b c d \n export'
+assert 'export e \n export'
 
 ## unset
 (


### PR DESCRIPTION
## やったこと
- 自作`export`にて, keyのみをmapに登録したものの出力の調整.
- `export`のテストケース追加.
```shell
bash$ export a b c d
...
declare -x a
declare -x b
declare -x c
declare -x d
bash$

minishell$ export a b c d
...
declare -x a
declare -x b
declare -x c
declare -x d
minishell$
```

## やってないこと
- 特になし.

## 参照
Closes #86 