### PR TITLE
93 fix builtin in pipe

### DIFF
--- a/src/exec/interpret.c
+++ b/src/exec/interpret.c
@@ -6,7 +6,7 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 02:34:47 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/07 14:38:38 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/12/10 13:13:42 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -154,6 +154,8 @@ static pid_t	exec_pipeline(t_node *node)
 		reset_signal();
 		prepare_pipe_child(node);
 		do_redirect(node->command->redirects);
+		if (is_builtin(node))
+			exit(exec_builtin(node));
 		argv = token_list_to_argv(node->command->args);
 		path = argv[0];
 		// TODO: is a directoryのエラーステータス

--- a/src/exec/interpret.c
+++ b/src/exec/interpret.c
@@ -6,7 +6,7 @@
 /*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 02:34:47 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/10 13:13:42 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/10 16:17:15 by yotsubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -153,9 +153,9 @@ static pid_t	exec_pipeline(t_node *node)
 		// child process
 		reset_signal();
 		prepare_pipe_child(node);
-		do_redirect(node->command->redirects);
 		if (is_builtin(node))
 			exit(exec_builtin(node));
+		do_redirect(node->command->redirects);
 		argv = token_list_to_argv(node->command->args);
 		path = argv[0];
 		// TODO: is a directoryのエラーステータス

--- a/test.sh
+++ b/test.sh
@@ -405,6 +405,9 @@ assert 'export nosuch hoge=nosuch [invalid]\n export | grep nosuch | sort'
 assert 'export nosuch="nosuch2=hoge"\nexport $nosuch\n export | grep nosuch | sort'
 assert 'export a b c d \n export'
 assert 'export e \n export'
+assert 'export 1'
+assert 'export %'
+assert 'export 1 f\n export'
 
 ## unset
 (
@@ -484,6 +487,13 @@ assert 'unset PWD \n cd \n echo $PWD \ncd /tmp\necho $PWD'
 assert 'unset PWD\ncd\necho $OLDPWD\ncd /tmp\necho $OLDPWD'
 assert 'unset PWD\ncd\nexport|grep PWD\ncd /tmp\nexport|grep PWD'
 assert 'unset PWD\ncd\nenv|grep PWD\ncd /tmp\nenv|grep PWD'
+
+## builtin in pipeline
+print_desc 'builtin in pipeline'
+assert 'echo hello | cat'
+assert 'export aaa=yeah\n export | grep yeah'
+assert 'exit | ls | grep M'
+assert 'cd | pwd | grep /'
 
 cleanup
 

--- a/test.sh
+++ b/test.sh
@@ -405,9 +405,6 @@ assert 'export nosuch hoge=nosuch [invalid]\n export | grep nosuch | sort'
 assert 'export nosuch="nosuch2=hoge"\nexport $nosuch\n export | grep nosuch | sort'
 assert 'export a b c d \n export'
 assert 'export e \n export'
-assert 'export 1'
-assert 'export %'
-assert 'export 1 f\n export'
 
 ## unset
 (


### PR DESCRIPTION
## やったこと
- pipeとbuiltin commandsを組み合わせたときに, 通常コマンドと同様にパスを探しに行ってしまっていた問題を修正.
- テストケースの追加

## やってないこと
- norm
- `builtin_exit`のみ, pipeと組み合わせて動かした際の出力がbashとことなる. => #102 

## 参照
#93 