### PR TITLE
117 norm include

### DIFF
--- a/include/macro.h
+++ b/include/macro.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   macro.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 14:13:22 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/11/23 02:15:52 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/12 16:24:30 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,14 +16,9 @@
 # define FALSE 0
 # define TRUE 1
 
-// エラーはいったん適当に定義してるだけ
 # define ERROR_TOKENIZE 258
 # define ERROR_PARSE 258
 # define ERROR_OPEN_REDIR 1
-#ifndef PATH_MAX
-# define PATH_MAX 100
-#endif
-//　↑これは仮. TODO:これしっかり直したい.
 
 # define SINGLE_QUOTE_CHAR '\''
 # define DOUBLE_QUOTE_CHAR '\"'

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 02:40:54 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/11/23 03:52:32 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/12 16:29:34 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,6 @@
 # include <errno.h>
 # include <fcntl.h>
 # include <limits.h>
-#include <sys/stat.h>
+# include <sys/stat.h>
 
 #endif

--- a/include/prototype.h
+++ b/include/prototype.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prototype.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 14:29:07 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/10 16:33:58 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:32:33 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,22 +45,22 @@ bool	is_builtin(t_node *node);
 bool	is_plusminus(char s);
 long	ft_strtol(const char *str);
 
-
 // env
 void	cleanup_map(t_map *map);
 t_item	*item_new(char *key, char *value);
 t_map	*map_new(void);
 char	*map_get(t_map *map, const char *key);
 int		map_put(t_map *map, const char *str);
-int		map_set(t_map *map, const char *key, const char *value, bool should_free);
+int		map_set(t_map *map, const char *key, \
+				const char *value, bool should_free);
 int		map_unset(t_map *map, const char *key);
 char	**get_environ(t_map *envmap);
 t_map	*init_env(void);
 
 // exec
-int	exec(t_node *node);
-int	open_redir_file(t_node *node);
-int	read_heredoc(const char *delimiter, bool is_delim_unquoted);
+int		exec(t_node *node);
+int		open_redir_file(t_node *node);
+int		read_heredoc(const char *delimiter, bool is_delim_unquoted);
 void	prepare_pipe(t_node *node);
 void	prepare_pipe_child(t_node *node);
 bool	is_redirect(t_node *node);
@@ -92,7 +92,7 @@ void	append_char(char **s, char c);
 void	expand(t_node *node);
 void	expand_variable_tok(t_token *tok);
 void	expand_variable(t_node *node);
-void	expand_special_parameter_str(char **dst,char **rest, char *p);
+void	expand_special_parameter_str(char **dst, char **rest, char *p);
 void	expand_variable_str(char **dst, char **rest, char *p);
 char	*expand_heardoc_line(char *line);
 bool	is_special_parameter(char *s);
@@ -137,6 +137,6 @@ t_map	*gs_env(int type, t_map *(*set_map)(void));
 int		gs_last_status(int type, int last_status);
 bool	gs_readline_interrupted(int type, bool readline_interrupted);
 bool	gs_syntax_error(int type, bool syntax_error);
-char 	*gs_line(int type, char *new_line);
+char	*gs_line(int type, char *new_line);
 
 #endif

--- a/include/struct.h
+++ b/include/struct.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   struct.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 13:54:38 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/11 12:25:31 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:38:08 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,52 +14,49 @@
 # define STRUCT_H
 # include "minishell.h"
 
-typedef enum	e_token_kind {
+typedef enum e_token_kind {
 	TK_WORD,
 	TK_RESERVED,
 	TK_OP,
 	TK_EOF,
-} t_token_kind;
+}	t_token_kind;
 
-typedef enum	e_node_kind {
+typedef enum e_node_kind {
 	ND_PIPELINE,
 	ND_SIMPLE_CMD,
 	ND_REDIR_OUT,
 	ND_REDIR_IN,
 	ND_REDIR_APPEND,
 	ND_REDIR_HEREDOC,
-} t_node_kind;
+}	t_node_kind;
 
-typedef enum	e_setget_kind {
+typedef enum e_setget_kind {
 	SET,
 	GET,
-} t_setget_kind;
+}	t_setget_kind;
 
 typedef struct s_token {
 	char			*word;
 	t_token_kind	kind;
 	bool			is_expanded;
 	struct s_token	*next;
-}	t_token ;
+}	t_token;
 
 typedef struct s_node {
 	t_node_kind		kind;
 	struct s_node	*next;
-	// CMD
 	t_token			*args;
 	struct s_node	*redirects;
-	// REDIR
 	int				targetfd;
 	t_token			*filename;
 	t_token			*delimiter;
 	bool			is_delim_unquoted;
 	int				filefd;
 	int				stashed_targetfd;
-	// PIPE
 	int				inpipe[2];
 	int				outpipe[2];
 	struct s_node	*command;
-}	t_node ;
+}	t_node;
 
 typedef struct s_item {
 	char			*key;
@@ -70,13 +67,5 @@ typedef struct s_item {
 typedef struct s_map {
 	t_item	item_head;
 }	t_map;
-
-extern bool	g_syntax_error;
-extern int		g_last_status;
-// TODO: グローバル変数を使わずともenvironを常に参照できるようにする. 
-extern t_map	*g_env;
-extern bool	g_readline_interrupted;
-extern volatile sig_atomic_t	g_sig;
-extern int	_rl_echo_control_chars;
 
 #endif

--- a/include/struct.h
+++ b/include/struct.h
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 13:54:38 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/12 16:38:08 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:39:23 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,5 +67,7 @@ typedef struct s_item {
 typedef struct s_map {
 	t_item	item_head;
 }	t_map;
+
+extern volatile sig_atomic_t	g_sig;
 
 #endif

--- a/src/builtin/builtin_pwd.c
+++ b/src/builtin/builtin_pwd.c
@@ -3,17 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_pwd.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/23 03:36:01 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/03 22:13:07 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:26:28 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-#ifndef PATH_MAX
-# define PATH_MAX 100
-#endif
 
 static bool	equal_inode(const char *path1, const char *path2)
 {

--- a/src/env/env.c
+++ b/src/env/env.c
@@ -3,20 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/14 17:31:05 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/09 13:34:47 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/12 16:26:23 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-#ifndef PATH_MAX
-# define PATH_MAX 100
-#endif
 
-// warning: この関数もしかしたらバグの原因になりうる. 
-// TODO: init_envの整形. 
 t_map	*init_env(void)
 {
 	extern char	**environ;

--- a/src/signal/signal.c
+++ b/src/signal/signal.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:36:31 by tkitahar          #+#    #+#             */
-/*   Updated: 2024/12/05 16:39:01 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/12 16:38:03 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,8 @@ int	check_state(void)
 
 void	setup_signal(void)
 {
+	extern int	_rl_echo_control_chars;
+
 	_rl_echo_control_chars = 1;
 	rl_outstream = stderr;
 	if (isatty(STDIN_FILENO))


### PR DESCRIPTION
## やったこと
- `include`ディレクトリのnorm対応. 
- 不要なマクロ, 環境変数の削除. 
- テスターによる動作確認. 

## やってないこと
- 特になし. 

## 検証例
- `norminette ./include`によるnorm errorの有無
- `./test.sh`による, 損傷箇所の有無

## 参照
#117 