### PR TITLE
112 fix env not sorted in bash

### DIFF
--- a/include/prototype.h
+++ b/include/prototype.h
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 14:29:07 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/13 15:37:32 by tkitahar         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:13:51 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ long	ft_strtol(const char *str);
 // env
 bool	is_identifier(const char *str);
 void	item_update(t_item *item, const char *value, bool should_free);
-void	item_apend_acending(const char *key, const char *value);
+void	item_apend(const char *key, const char *value);
 void	cleanup_map(t_map *map);
 t_map	*map_new(void);
 char	*map_get(t_map *map, const char *key);

--- a/include/prototype.h
+++ b/include/prototype.h
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/14 14:29:07 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/14 13:13:51 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:49:42 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@ long	ft_strtol(const char *str);
 
 // env
 bool	is_identifier(const char *str);
+t_item	*item_new(const char *key, const char *value);
 void	item_update(t_item *item, const char *value, bool should_free);
 void	item_apend(const char *key, const char *value);
 void	cleanup_map(t_map *map);

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,13 +6,14 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 16:15:23 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/14 13:48:33 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 14:01:05 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	item_apend_acending(const char *key, const char *value, t_map *new_env)
+static void	item_apend_acending(const char *key, \
+								const char *value, t_map *new_env)
 {
 	t_item	*item;
 	t_item	*new;

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,17 +6,64 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 16:15:23 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/12 18:12:59 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:48:33 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+static void	item_apend_acending(const char *key, const char *value, t_map *new_env)
+{
+	t_item	*item;
+	t_item	*new;
+	t_item	*prev;
+
+	item = &(new_env->item_head);
+	if (value == NULL)
+		new = item_new(key, NULL);
+	else
+		new = item_new(key, value);
+	if (item->next == NULL)
+		item->next = new;
+	else
+	{
+		prev = item;
+		item = item->next;
+		while (item != NULL && ft_strcmp(key, item->key) > 0)
+		{
+			prev = item;
+			item = item->next;
+		}
+		prev->next = new;
+		new->next = item;
+	}
+}
+
+static t_map	*make_sort_env(t_map *env)
+{
+	t_map	*new_env;
+	t_item	*item;
+
+	new_env = map_new();
+	item = env->item_head.next;
+	while (item)
+	{
+		if (new_env->item_head.next == NULL)
+			new_env->item_head.next = item_new(item->key, item->value);
+		else
+			item_apend_acending(item->key, item->value, new_env);
+		item = item->next;
+	}
+	return (new_env);
+}
+
 static void	print_allenv(void)
 {
 	t_item	*item;
+	t_map	*env;
 
-	item = gs_env(GET, NULL)->item_head.next;
+	env = make_sort_env(gs_env(GET, NULL));
+	item = env->item_head.next;
 	while (item)
 	{
 		if (item->value)
@@ -25,6 +72,7 @@ static void	print_allenv(void)
 			ft_printf("declare -x %s\n", item->key);
 		item = item->next;
 	}
+	free_map(env);
 }
 
 int	builtin_export(char **argv)

--- a/src/destruct/free_map.c
+++ b/src/destruct/free_map.c
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 22:39:25 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/13 12:58:11 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:55:49 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ void	free_map(t_map *map)
 	if (map == NULL)
 		return ;
 	item = map->item_head.next;
-	free_item(item->next);
+	free_item(item);
 	free(map);
 	map = NULL;
 }

--- a/src/env/map.c
+++ b/src/env/map.c
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/13 21:33:25 by yotsubo           #+#    #+#             */
-/*   Updated: 2024/12/12 19:45:15 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:13:56 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ int	map_set(t_map *map, const char *key, const char *value, bool should_free)
 	if (item != NULL)
 		item_update(item, value, should_free);
 	else
-		item_apend_acending(key, value);
+		item_apend(key, value);
 	return (0);
 }
 

--- a/src/env/map_utils.c
+++ b/src/env/map_utils.c
@@ -6,7 +6,7 @@
 /*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/12 19:44:55 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/14 11:43:25 by yuotsubo         ###   ########.fr       */
+/*   Updated: 2024/12/14 13:13:32 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,11 +50,10 @@ void	item_update(t_item *item, const char *value, bool should_free)
 		item->value = xstrdup(value);
 }
 
-void	item_apend_acending(const char *key, const char *value)
+void	item_apend(const char *key, const char *value)
 {
 	t_item	*item;
 	t_item	*new;
-	t_item	*prev;
 
 	item = &(gs_env(GET, NULL)->item_head);
 	if (value == NULL)
@@ -65,14 +64,8 @@ void	item_apend_acending(const char *key, const char *value)
 		item->next = new;
 	else
 	{
-		prev = item;
-		item = item->next;
-		while (item != NULL && ft_strcmp(key, item->key) > 0)
-		{
-			prev = item;
+		while (item->next != NULL)
 			item = item->next;
-		}
-		prev->next = new;
-		new->next = item;
+		item->next = new;
 	}
 }


### PR DESCRIPTION
## やったこと
- `env`コマンドではsortされていない環境変数が, `export`コマンドではsortされた環境変数が出力されるように調整. 
- `free_map()`内にあった, memory leakを修正.

## やってないこと
- `env`の出力と完璧に出力を合わせること. 

## 参照
#112 