### PR TITLE
108 fix syntax error multiple times

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yotsubo <y.otsubo.886@ms.saitama-u.ac.j    +#+  +:+       +#+        */
+/*   By: yuotsubo <yuotsubo@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/13 01:47:03 by yuotsubo          #+#    #+#             */
-/*   Updated: 2024/12/05 17:34:54 by yotsubo          ###   ########.fr       */
+/*   Updated: 2024/12/14 14:45:04 by yuotsubo         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,7 @@ int	main(void)
 			add_history(line);
 		interpret(line);
 		free(line);
+		gs_syntax_error(SET, FALSE);
 	}
 	builtin_exit(NULL);
 }


### PR DESCRIPTION
## やったこと
- `syntax_error`のフラグを初期化する処理を`main()`に追加. 

## やってないこと
- `test.sh`のsignal error一個でたけど無問題
```shell
<test.sh>

[exit " \t \n 42 \t \n "]  status OK, expected 2 but got 127
```
これは, `echo -e -n 'exit " \t \n 42 \t \n "' | bash`という渡し方ならば, bashは複数行にまたがって見るような実装になっているが, minishellでは, 
```shell
yuotsubo@c1r5s7:~/programs/mini-shell$ echo -e -n 'exit " \t \n 42 \t \n "' | ./minishell 
minishell$ exit "  
minishell: syntax error near unexpected character `' in Unclosed double quote
minishell$  42  
minishell: 42: command not found
minishell$  "
minishell: syntax error near unexpected character `' in Unclosed double quote
minishell$ exit
yuotsubo@c1r5s7:~/programs/mini-shell$
```
というように, 一行ずつ見ていく実装のため, 最後の`syntax error`時点での終了ステータス127が入っているので, 問題ない.

## 参照
#108 